### PR TITLE
Keep original request parameter

### DIFF
--- a/lib/sinatra/browse.rb
+++ b/lib/sinatra/browse.rb
@@ -71,6 +71,12 @@ module Sinatra::Browse
     @default_on_error
   end
 
+  module HelperMethods
+    def orig_params
+      @orig_params
+    end
+  end
+
   def self.registered(app)
     @app = app
 
@@ -91,6 +97,11 @@ module Sinatra::Browse
     }
 
     app.default_on_error { |error_hash| _default_on_error(error_hash) }
+
+    app.before do
+      @orig_params = @params.dup.freeze
+    end
+    app.helpers HelperMethods
 
     app.before do
       browse_route = app.browse_routes_for(request.request_method, request.path_info)

--- a/spec/dummy-app/app.rb
+++ b/spec/dummy-app/app.rb
@@ -87,8 +87,13 @@ class App < Sinatra::Base
   param :format, :String, format: /^nw-[a-z]{1,8}$/ #TODO: Generate examples in docs
   param :min_length, :String, min_length: 5
   param :max_length, :String, max_length: 5
+  param :get_original, :String
   get "/features/string_validation" do
-    params.to_json
+    if params[:get_original]
+      orig_params.to_json
+    else
+      params.to_json
+    end
   end
 
   param :single_digit, :Integer, in: 1..9
@@ -100,24 +105,37 @@ class App < Sinatra::Base
   end
 
   def self.helper_method
+    param :get_original, :String
     param :reused, :String, in: ["joske", "jefke"]
   end
 
   helper_method
   get "/features/options_override/not_overridden" do
-    params.to_json
+    if params["get_original"]
+      orig_params.to_json
+    else
+      params.to_json
+    end
   end
 
   helper_method
   param_options :reused, default: "joske"
   get "/features/options_override/default_added" do
-    params.to_json
+    if params["get_original"]
+      orig_params.to_json
+    else
+      params.to_json
+    end
   end
 
   helper_method
   param_options :reused, in: ["jossefien", "nonkel_jan"]
   get "/features/options_override/in_replaced" do
-    params.to_json
+    if params["get_original"]
+      orig_params.to_json
+    else
+      params.to_json
+    end
   end
 
   param :a, :String, depends_on: :b

--- a/spec/parameter_overriding_spec.rb
+++ b/spec/parameter_overriding_spec.rb
@@ -9,7 +9,11 @@ describe "overriding parameter options with param_options" do
       expect(status).to eq 400
       get("features/options_override/#{url}", reused: "joske")
       expect(body["reused"]).to eq("joske")
+      get("features/options_override/#{url}?get_original=1", reused: "joske")
+      expect(body["reused"]).to eq("joske")
       get("features/options_override/#{url}", reused: "jefke")
+      expect(body["reused"]).to eq("jefke")
+      get("features/options_override/#{url}?get_original=1", reused: "jefke")
       expect(body["reused"]).to eq("jefke")
     end
   end
@@ -26,6 +30,8 @@ describe "overriding parameter options with param_options" do
     it "has set a default value" do
       get("features/options_override/default_added")
       expect(body["reused"]).to eq("joske")
+      get("features/options_override/default_added?get_original=1")
+      expect(body["reused"]).to be_nil
     end
   end
 

--- a/spec/shared_validation_spec.rb
+++ b/spec/shared_validation_spec.rb
@@ -25,6 +25,8 @@ describe "transform" do
   it "does a to_proc on whatever was given and calls it on the parameter" do
     get("features/string_validation", transform: "joske")
     expect(body["transform"]).to eq("JOSKE")
+    get("features/string_validation?get_original=1", transform: "joske")
+    expect(body["transform"]).to eq("joske")
   end
 
   #TODO: Define behaviour for something that doesn't respond to to_proc


### PR DESCRIPTION
Sinatra::Browse modifies ``@params`` hash object when the validators are specified ``:transform`` or ``:default``. There is no way to get the original values in route block which passes all validations.