### PR TITLE
Fix default values nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * `Changed` Adapted the changelog format to follow the same style as our other projects.
 
+* `Fixed` A bug where parameters that were not required and had no default value would be set to nil if they were missing from a request.
+
 ## [0.6] - 2015-06-24
 
 * `Added` New parameter type: `DateTime`.

--- a/lib/sinatra/browse/parameter_type.rb
+++ b/lib/sinatra/browse/parameter_type.rb
@@ -53,6 +53,10 @@ module Sinatra::Browse
       @default.is_a?(Proc) ? @default.call : @default
     end
 
+    def default_set?
+      ! @default.nil?
+    end
+
     def required?
       @required
     end

--- a/lib/sinatra/browse/route.rb
+++ b/lib/sinatra/browse/route.rb
@@ -40,7 +40,7 @@ module Sinatra::Browse
       @param_declarations.each do |name, pd|
         name = name.to_s # The params hash uses strings but declarations use symbols
 
-        params[name] ||= pd.default
+        params[name] ||= pd.default if pd.default_set?
 
         # We specifically check for nil here since a boolean's default can be false
         if params[name].nil?

--- a/spec/dummy-app/app.rb
+++ b/spec/dummy-app/app.rb
@@ -101,6 +101,8 @@ class App < Sinatra::Base
   param :a, :String, default: "yay"
   param :b, :Integer, default: 11
   param :c, :Boolean, default: false
+  param :n, :String, default: nil
+  param :default_not_set, :String
   get "/features/default" do
     params.to_json
   end

--- a/spec/shared_validation_spec.rb
+++ b/spec/shared_validation_spec.rb
@@ -27,11 +27,10 @@ describe "default values" do
     end
   end
 
-  context "with 'nil' as the default" do
-    it "will explicitely set nil as expected (not leave the missing value empty)" do
+  context "with nil as the default" do
+    it "will create a key with nil as it's value" do
       get("features/default")
-      p body
-      expect(body['n']).to eq("") # nil will coerce into an empty string
+      expect(body['n']).to be_nil
     end
   end
 end

--- a/spec/shared_validation_spec.rb
+++ b/spec/shared_validation_spec.rb
@@ -19,6 +19,21 @@ describe "default values" do
       expect(body['a']).to eq(2)
     end
   end
+
+  context "with no default provided" do
+    it "will not set any value (including nil) for missing parameters" do
+      get("features/default")
+      expect(body).not_to have_key('default_not_set')
+    end
+  end
+
+  context "with 'nil' as the default" do
+    it "will explicitely set nil as expected (not leave the missing value empty)" do
+      get("features/default")
+      p body
+      expect(body['n']).to eq("") # nil will coerce into an empty string
+    end
+  end
 end
 
 describe "transform" do


### PR DESCRIPTION
This fixed a bug where missing parameter would be set to nil if they were not required and had no default value.

Take the following example.

```ruby
   param :default_set, :String, default: "joske"
   param :default_not_set, :String
   get "/features/default" do
     ....
   end
```

Sending a request to this route without any parameters would give you this result.

params contains: {default_set: "joske", default_not_set: nil}

That can be a problem when using the `has_key?` method or something similar. I fixed it to have the following result instead:

params constains: {default_set "joske"}