### PR TITLE
Update ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.2
   - 2.2.0
+  - 2.2.2
   - jruby
   - rbx-2.2.7
   - ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* `Added` Support for Ruby 2.2.2. That means the unit tests are now run on that version. It was probably working already anyway.
+
 * `Changed` Adapted the changelog format to follow the same style as our other projects.
 
 * `Fixed` A bug where parameters that were not required and had no default value would be set to nil if they were missing from a request.
+
+* `Removed` Support for Ruby 1.9.3 as Ruby officialy dropped support for it in February this year. It might still work but Sinatra-browse will no longer be unit tested against it.
 
 ## [0.6] - 2015-06-24
 


### PR DESCRIPTION
Unit test against ruby 2.2.2 and no longer unit test against 1.9.3.

Ruby has officially ended support for 1.9.3 earlier this year so Sinatra-browse will no longer support it, even if it might still work.