### PR TITLE
Rescue coerce errors and return an error hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to sinatra-browse will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Next version
+
+* `Changed` Incoercible params, such as an invalid `DateTime` param, will give back a 400 with reason `invalid` instead of raising an exception.
+
 ## [0.6.1] - 2015-07-07
 
 * `Added` Support for Ruby 2.2.2. That means the unit tests are now run on that version. It was probably working already anyway.

--- a/lib/sinatra/browse/route.rb
+++ b/lib/sinatra/browse/route.rb
@@ -48,7 +48,11 @@ module Sinatra::Browse
           next
         end
 
-        params[name] = pd.coerce(params[name])
+        begin
+          params[name] = pd.coerce(params[name])
+        rescue
+          return false, pd.build_error_hash(:invalid, params[name])
+        end
 
         success, error_hash = pd.validate(params)
         return false, error_hash unless success

--- a/spec/date_time_validation_spec.rb
+++ b/spec/date_time_validation_spec.rb
@@ -17,6 +17,13 @@ describe "DateTime validation" do
     end
   end
 
+  context "with an invalid date" do
+    it "validates the date and returns an error" do
+      get("features/date_time_validation", string_min: "2019/02/29")
+      expect(status).to eq 400
+    end
+  end
+
   [
     [:max, {string_max: '2005-1-1'}],
     [:min, {string_min: '2014-2-4'}]


### PR DESCRIPTION
When using DateTime params (though possibly for other types too) the coerce step can fail because the date is invalid (it can be because it's a day that doesn't exist, such as 29/2 on non-leap years, or a string that cannot be parsed by DateTime).
The current behavior is to let this error bubble up and allow sinatra to return a 500. However, it should be caught by sinatra-browse and return a 400 for a graceful error.
This changes the behavior to catch exceptions around the coerce and return an error. I'm using a generic exception catch, but it could be more specialized to catch an `ArgumentError`, which is thrown by DateTime.parse.